### PR TITLE
fix(remix-pagination): preserve multiple values for search params

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@commitlint/config-conventional": "17.0.3",
     "@commitlint/config-nx-scopes": "17.0.0",
     "@commitlint/cz-commitlint": "17.0.3",
+    "@commitlint/prompt-cli": "^17.6.1",
     "@commitlint/types": "17.0.0",
     "@jscutlery/semver": "2.25.2",
     "@nrwl/cli": "14.5.1",

--- a/packages/remix-pagination/package.json
+++ b/packages/remix-pagination/package.json
@@ -15,8 +15,7 @@
   "sideEffects": false,
   "dependencies": {
     "clsx": "~1.0.0",
-    "react-icons": "~4.0.0",
-    "ufo": "~0.8.0"
+    "react-icons": "~4.0.0"
   },
   "peerDependencies": {
     "@remix-run/react": "^1.8.0"

--- a/packages/remix-pagination/project.json
+++ b/packages/remix-pagination/project.json
@@ -7,8 +7,7 @@
       "react",
       "react-dom",
       "react-icons",
-      "regenerator-runtime",
-      "ufo"
+      "regenerator-runtime"
     ],
     "development": [
       "@nrwl/eslint-plugin-nx",

--- a/packages/remix-pagination/src/lib/remix-pagination.tsx
+++ b/packages/remix-pagination/src/lib/remix-pagination.tsx
@@ -3,7 +3,6 @@ import {
   BsChevronLeft as PreviousIcon,
   BsChevronRight as NextIcon,
 } from 'react-icons/bs';
-import { withQuery } from 'ufo';
 
 import { Item as ItemComponent } from './components/Item';
 import { Link as LinkComponent } from './components/Link';
@@ -59,9 +58,8 @@ export const RemixPagination: FC<RemixPaginationProps> = ({
 }) => {
   const [params] = useSearchParams();
 
-  const query = Object.fromEntries(params.entries());
 
-  const currentPage = Number(query[pageQuery] || 1);
+  const currentPage = Number(params.has(pageQuery) ? params.get(pageQuery) : 1);
 
   const isLastPage = currentPage * size >= total;
   const pageNumbers = getPageNumbers({
@@ -71,8 +69,12 @@ export const RemixPagination: FC<RemixPaginationProps> = ({
     ellipsesText,
   });
 
-  const url = (page: string | number) =>
-    withQuery('', { ...query, [pageQuery]: page.toString() });
+
+  const url = (page: string | number) => {
+      const pageParams = new URLSearchParams(params)
+      pageParams.set(pageQuery,page.toString())
+      return '?'+pageParams.toString()
+    };
 
   if (pageNumbers.length === 0) return null;
 


### PR DESCRIPTION
prior to this patch, URLSearchParams was being passed through Object.entries, which makes multiple values for the same param, e.g. q=3&q=4&q=5, be replaced with only one entry q=5. using URLSearchParams for the entire process of creating the page link (instead of the ufo library) resolves this problem

fixes #3 